### PR TITLE
Add migration confirmation page

### DIFF
--- a/main.go
+++ b/main.go
@@ -13,7 +13,6 @@ import (
 
 func main() {
 	manager.Initialize()
-	database.RunBackup(config.GetDatabasePath())
 	database.Initialize(config.GetDatabasePath())
 	api.Start()
 	blockForever()

--- a/pkg/api/migrate.go
+++ b/pkg/api/migrate.go
@@ -1,0 +1,59 @@
+package api
+
+import (
+	"fmt"
+	"html/template"
+	"net/http"
+
+	"github.com/stashapp/stash/pkg/database"
+)
+
+type migrateData struct {
+	ExistingVersion uint
+	MigrateVersion uint
+	BackupPath string
+}
+
+func getMigrateData() migrateData {
+	return migrateData{
+		ExistingVersion: database.Version(),
+		MigrateVersion: database.AppSchemaVersion(),
+		BackupPath: "",
+	}
+}
+
+func getMigrateHandler(w http.ResponseWriter, r *http.Request) {
+	if !database.NeedsMigration() {
+		http.Redirect(w, r, "/", 301)
+		return
+	}
+
+	data, _ := setupUIBox.Find("migrate.html")
+	templ, err := template.New("Migrate").Parse(string(data))
+	if err != nil {
+		http.Error(w, fmt.Sprintf("error: %s", err), 500)
+		return
+	}
+
+	err = templ.Execute(w, getMigrateData())
+	if err != nil {
+		http.Error(w, fmt.Sprintf("error: %s", err), 500)
+	}
+}
+
+func doMigrateHandler(w http.ResponseWriter, r *http.Request) {
+	err := r.ParseForm()
+	if err != nil {
+		http.Error(w, fmt.Sprintf("error: %s", err), 500)
+	}
+
+	r.Form.Get("backuppath")
+
+	// TODO - perform database backup
+
+	err = database.RunMigrations()
+	if err != nil {
+		http.Error(w, fmt.Sprintf("error: %s", err), 500)
+	}
+	http.Redirect(w, r, "/", 301)
+}

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -20,6 +20,7 @@ import (
 	"github.com/gobuffalo/packr/v2"
 	"github.com/gorilla/websocket"
 	"github.com/rs/cors"
+	"github.com/stashapp/stash/pkg/database"
 	"github.com/stashapp/stash/pkg/logger"
 	"github.com/stashapp/stash/pkg/manager"
 	"github.com/stashapp/stash/pkg/manager/config"
@@ -83,6 +84,7 @@ func Start() {
 	r.Use(cors.AllowAll().Handler)
 	r.Use(BaseURLMiddleware)
 	r.Use(ConfigCheckMiddleware)
+	r.Use(DatabaseCheckMiddleware)
 
 	recoverFunc := handler.RecoverFunc(func(ctx context.Context, err interface{}) error {
 		logger.Error(err)
@@ -126,6 +128,9 @@ func Start() {
 
 		http.ServeFile(w, r, fn)
 	})
+
+	// Serve the migration UI
+	r.Get("/migrate", getMigrateHandler)
 
 	// Serve the setup UI
 	r.HandleFunc("/setup*", func(w http.ResponseWriter, r *http.Request) {
@@ -317,6 +322,20 @@ func ConfigCheckMiddleware(next http.Handler) http.Handler {
 		if !config.IsValid() && shouldRedirect {
 			if !strings.HasPrefix(r.URL.Path, "/setup") {
 				http.Redirect(w, r, "/setup", 301)
+				return
+			}
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+func DatabaseCheckMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ext := path.Ext(r.URL.Path)
+		shouldRedirect := ext == "" && r.Method == "GET"
+		if shouldRedirect && database.NeedsMigration() {
+			if !strings.HasPrefix(r.URL.Path, "/migrate") {
+				http.Redirect(w, r, "/migrate", 301)
 				return
 			}
 		}

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -131,6 +131,7 @@ func Start() {
 
 	// Serve the migration UI
 	r.Get("/migrate", getMigrateHandler)
+	r.Post("/migrate", doMigrateHandler)
 
 	// Serve the setup UI
 	r.HandleFunc("/setup*", func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -17,7 +17,9 @@ import (
 )
 
 var DB *sqlx.DB
+var dbPath string
 var appSchemaVersion uint = 4
+var databaseSchemaVersion uint
 
 const sqlite3Driver = "sqlite3_regexp"
 
@@ -27,7 +29,21 @@ func init() {
 }
 
 func Initialize(databasePath string) {
-	runMigrations(databasePath)
+	dbPath = databasePath
+
+	if err := getDatabaseSchemaVersion(); err != nil {
+		panic(err)
+	}
+
+	if databaseSchemaVersion > appSchemaVersion {
+		panic(fmt.Sprintf("Database schema version %d is incompatible with required schema version %d", databaseSchemaVersion, appSchemaVersion))
+	}
+
+	// if migration is needed, then don't open the connection
+	if NeedsMigration() {
+		logger.Warnf("Database schema version %d does not match required schema version %d.", databaseSchemaVersion, appSchemaVersion)
+		return
+	}
 
 	// https://github.com/mattn/go-sqlite3
 	conn, err := sqlx.Open(sqlite3Driver, "file:"+databasePath+"?_fk=true")
@@ -55,34 +71,71 @@ func Reset(databasePath string) error {
 	return nil
 }
 
-// Migrate the database
-func runMigrations(databasePath string) {
+func NeedsMigration() bool {
+	return databaseSchemaVersion != appSchemaVersion
+}
+
+func AppSchemaVersion() uint {
+	return appSchemaVersion
+}
+
+func DatabaseBackupPath() string {
+	// TODO
+	return ""
+}
+
+func Version() uint {
+	return databaseSchemaVersion
+}
+
+func getMigrate() (*migrate.Migrate, error) {
 	migrationsBox := packr.New("Migrations Box", "./migrations")
 	packrSource := &Packr2Source{
 		Box:        migrationsBox,
 		Migrations: source.NewMigrations(),
 	}
 
-	databasePath = utils.FixWindowsPath(databasePath)
+	databasePath := utils.FixWindowsPath(dbPath)
 	s, _ := WithInstance(packrSource)
-	m, err := migrate.NewWithSourceInstance(
+	return migrate.NewWithSourceInstance(
 		"packr2",
 		s,
 		fmt.Sprintf("sqlite3://%s", "file:"+databasePath),
 	)
+}
+
+func getDatabaseSchemaVersion() error {
+	m, err := getMigrate()
+	if err != nil {
+		return err
+	}
+
+	databaseSchemaVersion, _, _ = m.Version()
+	m.Close()
+	return nil
+}
+
+// Migrate the database
+func RunMigrations() error {
+	m, err := getMigrate()
 	if err != nil {
 		panic(err.Error())
 	}
 
-	databaseSchemaVersion, _, _ := m.Version()
+	databaseSchemaVersion, _, _ = m.Version()
 	stepNumber := appSchemaVersion - databaseSchemaVersion
 	if stepNumber != 0 {
 		err = m.Steps(int(stepNumber))
 		if err != nil {
-			panic(err.Error())
+			return err
 		}
 	}
 	m.Close()
+
+	// re-initialise the database
+	Initialize(dbPath)
+
+	return nil
 }
 
 func registerRegexpFunc() {

--- a/ui/setup/migrate.html
+++ b/ui/setup/migrate.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Stash</title>
+
+    <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Roboto:300,300italic,700,700italic">
+    <link rel="stylesheet" href="//cdn.rawgit.com/necolas/normalize.css/master/normalize.css">
+    <link rel="stylesheet" href="/setup/milligram.min.css">
+</head>
+<body>
+
+<div class="container">
+    <p>
+        Your current stash database is schema version <strong>{{.ExistingVersion}}</strong> and needs to be migrated to version <strong>{{.MigrateVersion}}</strong>.
+        This version of Stash will not function without migrating the database. <strong>The schema migration process is not reversible. Once the migration is 
+        performed, your database will be incompatible with previous versions of stash.</strong>
+    </p>
+
+    <p>
+        It is recommended that you backup your existing database before you migrate. We can do this for you, writing a backup to <code>{{.BackupPath}}</code> if required.
+    </p>
+    
+    <form action="/migrate" method="POST">
+        <fieldset>
+            <label for="stash">Backup database path (leave empty to disable backup):</label>
+            <input name="backuppath" type="text" value="{{.BackupPath}}" />
+
+            <div>
+                <input class="button button-black" type="submit" value="Perform schema migration">
+            </div>
+        </fieldset>
+    </form>
+</div>
+
+</body>
+</html>


### PR DESCRIPTION
If the database needs migrating, then the server will redirect to a page allowing the user to confirm the operation, with a pre-filled backup path. Changed `Backup` to just perform the backup, given a backup path.